### PR TITLE
Windows implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,5 @@
 [![Linux & OS X build status](https://img.shields.io/travis/AndyBarron/app-dirs-rs.svg?label=Linux%20%26%20OS%20X%20builds)](https://travis-ci.org/AndyBarron/app-dirs-rs)
 [![Windows build status](https://img.shields.io/appveyor/ci/AndyBarron/app-dirs-rs.svg?label=Windows%20builds)](https://ci.appveyor.com/project/AndyBarron/app-dirs-rs)
 
-**Windows not yet supported*
 
 More info coming soon!

--- a/src/common.rs
+++ b/src/common.rs
@@ -50,6 +50,7 @@ impl AppDirType {
     }
 }
 
+#[derive(Debug)]
 pub enum AppDirError {
     Io(std::io::Error),
     // NotFound(PathBuf),

--- a/src/imp/platform/windows.rs
+++ b/src/imp/platform/windows.rs
@@ -1,6 +1,13 @@
 use common::*;
 use std::path::PathBuf;
+use std::env;
+use AppDirType::*;
 
 pub fn get_app_dir(t: AppDirType) -> AppDirResult<PathBuf> {
-    unimplemented!()
+    match t {
+        UserConfig | UserData | SharedConfig | SharedData =>
+            env::var("APPDATA"),
+        UserCache =>
+            env::var("LOCALAPPDATA"),
+    }.and_then(|x| Ok(PathBuf::from(x))).or_else(|_| Err(AppDirError::NotSupported))
 }


### PR DESCRIPTION
The implementation uses Appdata/Local for UserCache. And uses Appdata/Roaming for setting and data.

I also had to derive debug for AppDirError, to get the test to compile, since println won't be able to format it otherwise.