### PR TITLE
Accept paths as AsRef<Path>.

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,7 +1,7 @@
 use std;
 
 /// Struct that holds information about your app.
-/// 
+///
 /// It's recommended to create a single `const` instance of `AppInfo`:
 ///
 /// ```
@@ -58,9 +58,6 @@ impl AppDataType {
     }
 }
 
-const ERR_NOT_SUPPORTED: &'static str = "App data directories not supported";
-const ERR_INVALID_APP_INFO: &'static str = "Invalid app name or author";
-
 /// Error type for any `app_dirs` operation.
 #[derive(Debug)]
 pub enum AppDirsError {
@@ -72,16 +69,15 @@ pub enum AppDirsError {
     /// App info given to this library was invalid (e.g. app name or author
     /// were empty).
     InvalidAppInfo,
+    /// An absolute path was provided where a relative path was required.
+    NotRelativePath,
+    /// A string containing invalid UTF-8 was provided where a UTF-8 string was required.
+    InvalidUtf8,
 }
 
 impl std::fmt::Display for AppDirsError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-        use AppDirsError::*;
-        match *self {
-            Io(ref e) => e.fmt(f),
-            NotSupported => f.write_str(ERR_NOT_SUPPORTED),
-            InvalidAppInfo => f.write_str(ERR_INVALID_APP_INFO),
-        }
+        write!(f, "{}", (self as &std::error::Error).description())
     }
 }
 
@@ -92,14 +88,15 @@ impl std::error::Error for AppDirsError {
             Io(ref e) => e.description(),
             NotSupported => "App data directories not supported",
             InvalidAppInfo => "Invalid app name or author",
+            NotRelativePath => "Relative path required",
+            InvalidUtf8 => "Invalid UTF-8 provided",
         }
     }
     fn cause(&self) -> Option<&std::error::Error> {
         use AppDirsError::*;
         match *self {
             Io(ref e) => Some(e),
-            NotSupported => None,
-            InvalidAppInfo => None,
+            _ => None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ mod tests {
             name: "Awesome App".into(),
             author: "Dedicated Dev".into(),
         };
-        let path = "/.not-hidden/subfolder!/with?/uni.code/¡Olé!/";
+        let path = ::std::path::Path::new("/.not-hidden/subfolder!/with?/uni.code/¡Olé!/");
         let types = [UserConfig, UserData, UserCache, SharedData, SharedConfig];
         for &t in types.iter() {
             println!("{:?} data root = {:?}", t, get_data_root(t));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,7 @@
+use std::ffi::OsStr;
+
+use common::AppDirsError;
+
 /// Returns a cross-platform-filename-safe version of any string.
 ///
 /// This is used internally to generate app data directories based on app
@@ -25,4 +29,14 @@ pub fn sanitized(component: &str) -> String {
         }
     }
     buf
+}
+
+/// Attempts to sanitize an `OsStr`, using the logic as `sanitized`.
+///
+/// Returns an error if the provided `component` is invalid UTF-8.
+pub fn os_sanitized(component: &OsStr) -> Result<String, AppDirsError> {
+    match component.to_str() {
+        Some(component) => Ok(sanitized(component)),
+        None => Err(AppDirsError::InvalidUtf8),
+    }
 }


### PR DESCRIPTION
This patch changes the `path` parameters to functions from `&str` to `AsRef<Path>`. The benefit of doing this I see is:

1. The same function will be able to accept several different types as input, notably `Path` and `PathBuf`.
2. Manipulating paths internally is probably a safer approach than using string slices, since the `Path` API already provides cross-platform path behavior not inherent to strings.

This is a work in progress and not really intended to be merged as-is. Glancing quickly at the test output, I don't even think it's working yet. But if you want to make this change I can make sure it works and clean it up according to whatever style you prefer.