### PR TITLE
Changes paths to match Windows standards.

### DIFF
--- a/src/imp/platform/windows.rs
+++ b/src/imp/platform/windows.rs
@@ -31,9 +31,9 @@ pub const USE_AUTHOR: bool = true;
 
 pub fn get_app_dir(t: AppDataType) -> Result<PathBuf, AppDirsError> {
     let folder_id = match t {
-        UserConfig | UserData => &FOLDERID_RoamingAppData,
+        UserConfig => &FOLDERID_RoamingAppData,
         SharedConfig | SharedData => &FOLDERID_ProgramData,
-        UserCache => &FOLDERID_LocalAppData,
+        UserCache | UserData => &FOLDERID_LocalAppData,
     };
     get_folder_path(folder_id).map(|os_str| os_str.into())
 }


### PR DESCRIPTION
Fixes #16 and #17.

This changes the location of several folders to match Windows standards.  The full list can be found at https://msdn.microsoft.com/en-us/library/windows/desktop/dd378457(v=vs.85).aspx, though you will have to go to other MSDN articles to get details of their intended use:
[Local App Data](https://msdn.microsoft.com/en-us/windows/uwp/app-settings/store-and-retrieve-app-data#local-app-data)
[Roaming App Data](https://msdn.microsoft.com/en-us/windows/uwp/app-settings/store-and-retrieve-app-data#roaming-data)
[Program Data](https://msdn.microsoft.com/en-us/library/mt674655%28v=vs.85%29.aspx#10._apps_must_install_to_the_correct_folders_by_default)

Note: This is a breaking change so if this project follows semantic versioning it should be released as a major version bump.