### PR TITLE
Owning strings

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -42,8 +42,8 @@ pub struct StaticAppInfo {
 /// config file.
 ///
 /// ```
-/// use app_dirs::DynamicAppInfo;
-/// let APP_INFO = DynamicAppInfo{name: "Awesome App".to_string(), author: "Dedicated Dev".to_string()};
+/// use app_dirs::OwningAppInfo;
+/// let APP_INFO = OwningAppInfo{name: "Awesome App".to_string(), author: "Dedicated Dev".to_string()};
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct OwningAppInfo {
@@ -72,7 +72,6 @@ impl AppInfo for OwningAppInfo {
         &self.author
     }
 }
-
 
 /// Enum specifying the type of app data you want to store.
 ///

--- a/src/common.rs
+++ b/src/common.rs
@@ -2,14 +2,7 @@ use std;
 
 
 
-/// Struct that holds information about your app.
-///
-/// It's recommended to create a single `const` instance of `AppInfo`:
-///
-/// ```
-/// use app_dirs::StaticAppInfo;
-/// const APP_INFO: StaticAppInfo = StaticAppInfo{name: "Awesome App", author: "Dedicated Dev"};
-/// ```
+/// Trait for a struct that holds information about your app.
 ///
 /// # Caveats
 /// Functions in this library sanitize any characters that could be
@@ -19,6 +12,22 @@ use std;
 ///
 /// The `author` property is currently only used by Windows, as macOS and *nix
 /// specifications don't require it. Make sure your `name` string is unique!
+pub trait AppInfo {
+    /// Name of your app (e.g. "Hearthstone").
+    fn name(&self) -> &str;
+    /// Author of your app (e.g. "Blizzard").
+    fn author(&self) -> &str;
+}
+
+/// Struct that holds fixed information about your app.
+/// 
+/// It's recommended to create a single `const` instance of `StaticAppInfo`:
+///
+/// ```
+/// use app_dirs::StaticAppInfo;
+/// const APP_INFO: StaticAppInfo = StaticAppInfo{name: "Awesome App", author: "Dedicated Dev"};
+/// ```
+///
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct StaticAppInfo {
     /// Name of your app (e.g. "Hearthstone").
@@ -27,19 +36,21 @@ pub struct StaticAppInfo {
     pub author: &'static str,
 }
 
+/// Struct that holds fixed information about your app for when it
+/// can't be determined at compile time.  For instance, a library might
+/// look for data in a location provided by a user or loaded from a
+/// config file.
+///
+/// ```
+/// use app_dirs::DynamicAppInfo;
+/// let APP_INFO = DynamicAppInfo{name: "Awesome App".to_string(), author: "Dedicated Dev".to_string()};
+/// ```
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct OwningAppInfo {
     /// Name of your app (e.g. "Hearthstone").
     pub name: String,
     /// Author of your app (e.g. "Blizzard").
     pub author: String,
-}
-
-pub trait AppInfo {
-    /// Name of your app (e.g. "Hearthstone").
-    fn name(&self) -> &str;
-    /// Author of your app (e.g. "Blizzard").
-    fn author(&self) -> &str;
 }
 
 impl AppInfo for StaticAppInfo {

--- a/src/common.rs
+++ b/src/common.rs
@@ -35,6 +35,39 @@ pub struct OwningAppInfo {
     pub author: String,
 }
 
+/// Let's see...
+///
+/// ```
+/// use app_dirs::*;
+/// const APP_INFO: EAppInfo = EAppInfo::StaticAppInfo{name: "Awesome App", author: "Dedicated Dev"};
+/// ```
+pub enum EAppInfo {
+    StaticAppInfo  {
+        /// Name of your app (e.g. "Hearthstone").
+        name: &'static str,
+        /// Author of your app (e.g. "Blizzard").
+        author: &'static str,
+    },
+    OwningAppInfo {
+        /// Name of your app (e.g. "Hearthstone").
+        name: String,
+        /// Author of your app (e.g. "Blizzard").
+        author: String,
+    }
+}
+
+/// ```
+/// use app_dirs::*;
+/// use std::borrow::Cow;
+/// const APP_INFO: CAppInfo = CAppInfo{name: Cow::Borrowed("Awesome App"), author: Cow::Borrowed("Dedicated Dev")};
+/// let e = CAppInfo{name: Cow::Owned("Awesome App".to_owned()), author: Cow::Owned("Dedicated Dev".to_owned())};
+/// ```
+use std::borrow::Cow;
+pub struct CAppInfo {
+    pub name: Cow<'static, str>,
+    pub author: Cow<'static, str>,
+}
+
 pub trait AppInfo {
     /// Name of your app (e.g. "Hearthstone").
     fn name(&self) -> &str;

--- a/src/common.rs
+++ b/src/common.rs
@@ -35,39 +35,6 @@ pub struct OwningAppInfo {
     pub author: String,
 }
 
-/// Let's see...
-///
-/// ```
-/// use app_dirs::*;
-/// const APP_INFO: EAppInfo = EAppInfo::StaticAppInfo{name: "Awesome App", author: "Dedicated Dev"};
-/// ```
-pub enum EAppInfo {
-    StaticAppInfo  {
-        /// Name of your app (e.g. "Hearthstone").
-        name: &'static str,
-        /// Author of your app (e.g. "Blizzard").
-        author: &'static str,
-    },
-    OwningAppInfo {
-        /// Name of your app (e.g. "Hearthstone").
-        name: String,
-        /// Author of your app (e.g. "Blizzard").
-        author: String,
-    }
-}
-
-/// ```
-/// use app_dirs::*;
-/// use std::borrow::Cow;
-/// const APP_INFO: CAppInfo = CAppInfo{name: Cow::Borrowed("Awesome App"), author: Cow::Borrowed("Dedicated Dev")};
-/// let e = CAppInfo{name: Cow::Owned("Awesome App".to_owned()), author: Cow::Owned("Dedicated Dev".to_owned())};
-/// ```
-use std::borrow::Cow;
-pub struct CAppInfo {
-    pub name: Cow<'static, str>,
-    pub author: Cow<'static, str>,
-}
-
 pub trait AppInfo {
     /// Name of your app (e.g. "Hearthstone").
     fn name(&self) -> &str;

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,12 +1,14 @@
 use std;
 
+
+
 /// Struct that holds information about your app.
 ///
 /// It's recommended to create a single `const` instance of `AppInfo`:
 ///
 /// ```
-/// use app_dirs::AppInfo;
-/// const APP_INFO: AppInfo = AppInfo{name: "Awesome App", author: "Dedicated Dev"};
+/// use app_dirs::StaticAppInfo;
+/// const APP_INFO: StaticAppInfo = StaticAppInfo{name: "Awesome App", author: "Dedicated Dev"};
 /// ```
 ///
 /// # Caveats
@@ -18,12 +20,48 @@ use std;
 /// The `author` property is currently only used by Windows, as macOS and *nix
 /// specifications don't require it. Make sure your `name` string is unique!
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct AppInfo {
+pub struct StaticAppInfo {
     /// Name of your app (e.g. "Hearthstone").
     pub name: &'static str,
     /// Author of your app (e.g. "Blizzard").
     pub author: &'static str,
 }
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct OwningAppInfo {
+    /// Name of your app (e.g. "Hearthstone").
+    pub name: String,
+    /// Author of your app (e.g. "Blizzard").
+    pub author: String,
+}
+
+pub trait AppInfo {
+    /// Name of your app (e.g. "Hearthstone").
+    fn name(&self) -> &str;
+    /// Author of your app (e.g. "Blizzard").
+    fn author(&self) -> &str;
+}
+
+impl AppInfo for StaticAppInfo {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn author(&self) -> &str {
+        self.author
+    }
+}
+
+impl AppInfo for OwningAppInfo {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn author(&self) -> &str {
+        &self.author
+    }
+}
+
 
 /// Enum specifying the type of app data you want to store.
 ///

--- a/src/imp/mod.rs
+++ b/src/imp/mod.rs
@@ -51,7 +51,7 @@ pub fn app_dir(t: AppDataType, app: &AppInfo, path: &str) -> Result<PathBuf, App
 /// it DOES NOT guarantee that the directory actually exists. (See
 /// [`app_dir`](fn.app_dir.html).)
 pub fn get_app_dir(t: AppDataType, app: &AppInfo, path: &str) -> Result<PathBuf, AppDirsError> {
-    if app.author.len() == 0 || app.name.len() == 0 {
+    if app.author().len() == 0 || app.name().len() == 0 {
         return Err(AppDirsError::InvalidAppInfo);
     }
     app_root(t, app).map(|mut root| {
@@ -83,14 +83,14 @@ pub fn app_root(t: AppDataType, app: &AppInfo) -> Result<PathBuf, AppDirsError> 
 /// it DOES NOT guarantee that the directory actually exists. (See
 /// [`app_root`](fn.app_root.html).)
 pub fn get_app_root(t: AppDataType, app: &AppInfo) -> Result<PathBuf, AppDirsError> {
-    if app.author.len() == 0 || app.name.len() == 0 {
+    if app.author().len() == 0 || app.name().len() == 0 {
         return Err(AppDirsError::InvalidAppInfo);
     }
     data_root(t).map(|mut root| {
         if platform::USE_AUTHOR {
-            root.push(utils::sanitized(app.author));
+            root.push(utils::sanitized(app.author()));
         }
-        root.push(utils::sanitized(app.name));
+        root.push(utils::sanitized(app.name()));
         root
     })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! extern crate app_dirs;
 //! use app_dirs::*;
 //!
-//! const APP_INFO: AppInfo = AppInfo{name: "CoolApp", author: "SuperDev"};
+//! const APP_INFO: StaticAppInfo = StaticAppInfo{name: "CoolApp", author: "SuperDev"};
 //!
 //! fn main () {
 //!     // Where should I store my app's per-user configuration data?
@@ -45,7 +45,7 @@ mod tests {
     use super::*;
     #[test]
     fn it_works() {
-        let info = AppInfo {
+        let info = StaticAppInfo {
             name: "Awesome App".into(),
             author: "Dedicated Dev".into(),
         };


### PR DESCRIPTION
PR to make `AppInfo` a trait and have different structures with different ownership semantics for it.  Resolves issue #19 

I still think there should be some way to use `Cow` to make this simpler, but it's less ergonomic.  Oh well.