### PR TITLE
Fix MacOS compilation error + cargo clippy

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -58,8 +58,8 @@ impl AppDataType {
     }
 }
 
-const ERR_NOT_SUPPORTED: &'static str = "App data directories not supported";
-const ERR_INVALID_APP_INFO: &'static str = "Invalid app name or author";
+const ERR_NOT_SUPPORTED: &str = "App data directories not supported";
+const ERR_INVALID_APP_INFO: &str = "Invalid app name or author";
 
 /// Error type for any `app_dirs` operation.
 #[derive(Debug)]
@@ -98,8 +98,7 @@ impl std::error::Error for AppDirsError {
         use AppDirsError::*;
         match *self {
             Io(ref e) => Some(e),
-            NotSupported => None,
-            InvalidAppInfo => None,
+            NotSupported | InvalidAppInfo=> None,
         }
     }
 }

--- a/src/imp/mod.rs
+++ b/src/imp/mod.rs
@@ -34,7 +34,7 @@ mod platform {
 /// create the full hierarchy. Therefore, a result of `Ok` guarantees that the
 /// returned path exists.
 pub fn app_dir(t: AppDataType, app: &AppInfo, path: &str) -> Result<PathBuf, AppDirsError> {
-    let path = try!(get_app_dir(t, app, &path));
+    let path = try!(get_app_dir(t, app, path));
     match fs::create_dir_all(&path) {
         Ok(..) => Ok(path),
         Err(e) => Err(e.into()),
@@ -51,11 +51,11 @@ pub fn app_dir(t: AppDataType, app: &AppInfo, path: &str) -> Result<PathBuf, App
 /// it DOES NOT guarantee that the directory actually exists. (See
 /// [`app_dir`](fn.app_dir.html).)
 pub fn get_app_dir(t: AppDataType, app: &AppInfo, path: &str) -> Result<PathBuf, AppDirsError> {
-    if app.author.len() == 0 || app.name.len() == 0 {
+    if app.author.is_empty() || app.name.is_empty() {
         return Err(AppDirsError::InvalidAppInfo);
     }
     app_root(t, app).map(|mut root| {
-        for component in path.split("/").filter(|s| s.len() > 0) {
+        for component in path.split('/').filter(|s| !s.is_empty()) {
             root.push(utils::sanitized(component));
         }
         root
@@ -83,7 +83,7 @@ pub fn app_root(t: AppDataType, app: &AppInfo) -> Result<PathBuf, AppDirsError> 
 /// it DOES NOT guarantee that the directory actually exists. (See
 /// [`app_root`](fn.app_root.html).)
 pub fn get_app_root(t: AppDataType, app: &AppInfo) -> Result<PathBuf, AppDirsError> {
-    if app.author.len() == 0 || app.name.len() == 0 {
+    if app.author.is_empty() || app.name.is_empty() {
         return Err(AppDirsError::InvalidAppInfo);
     }
     data_root(t).map(|mut root| {

--- a/src/imp/platform/macos.rs
+++ b/src/imp/platform/macos.rs
@@ -1,13 +1,13 @@
 use AppDataType::*;
 use common::*;
 use std::env::home_dir;
-use std::path::{Component, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 pub const USE_AUTHOR: bool = false;
 
 pub fn get_app_dir(t: AppDataType) -> Result<PathBuf, AppDirsError> {
     let dir_base: Result<PathBuf, AppDirsError> = if t.is_shared() {
-        Ok(Component::RootDir.as_ref().into())
+        Ok(Path::new(&Component::RootDir).into())
     } else {
         home_dir().ok_or_else(|| AppDirsError::NotSupported)
     };


### PR DESCRIPTION
```
$ cargo clippy
lib: app_dirs
   Compiling app_dirs v1.1.1 (file:///Users/korczis/dev/app-dirs-rs)
warning: this `match` has identical arm bodies
   --> src/common.rs:102:31
    |
102 |             InvalidAppInfo => None,
    |                               ^^^^
    |
    = note: #[warn(match_same_arms)] on by default
note: same as this
   --> src/common.rs:101:29
    |
101 |             NotSupported => None,
    |                             ^^^^
note: consider refactoring into `NotSupported | InvalidAppInfo`
   --> src/common.rs:101:29
    |
101 |             NotSupported => None,
    |                             ^^^^
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.186/index.html#match_same_arms

warning: this expression borrows a reference that is immediately dereferenced by the compiler
  --> src/imp/mod.rs:37:41
   |
37 |     let path = try!(get_app_dir(t, app, &path));
   |                                         ^^^^^ help: change this to: `path`
   |
   = note: #[warn(needless_borrow)] on by default
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.186/index.html#needless_borrow

warning: length comparison to zero
  --> src/imp/mod.rs:54:8
   |
54 |     if app.author.len() == 0 || app.name.len() == 0 {
   |        ^^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is more concise: `app.author.is_empty()`
   |
   = note: #[warn(len_zero)] on by default
   = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.186/index.html#len_zero

warning: length comparison to zero
  --> src/imp/mod.rs:54:33
   |
54 |     if app.author.len() == 0 || app.name.len() == 0 {
Fix MacOS compilation error + cargo clippy

error[E0619]: the type of this value must be known in this context
  --> /Users/korczis/.cargo/registry/src/github.com-1ecc6299db9ec823/app_dirs-1.1.1/src/imp/platform/macos.rs:10:40
   |
10 |         Ok(Component::RootDir.as_ref().into())
   |                                        ^^^^
```